### PR TITLE
Use SiraUtils Expose to not clash with other mods

### DIFF
--- a/Plugin/CustomFloorPlugin/Installers/PlatformsGameInstaller.cs
+++ b/Plugin/CustomFloorPlugin/Installers/PlatformsGameInstaller.cs
@@ -6,22 +6,17 @@ namespace CustomFloorPlugin.Installers
     internal class PlatformsGameInstaller : Installer
     {
         private readonly PlatformSpawner _platformSpawner;
-        private readonly ObstacleSaberSparkleEffectManager? _obstacleSaberSparkleEffectManager;
         private readonly MultiplayerPlayersManager? _multiplayerPlayersManager;
 
-        public PlatformsGameInstaller(PlatformSpawner platformSpawner, [InjectOptional] PlayerSpaceConvertor? playerSpaceConvertor, [InjectOptional] MultiplayerPlayersManager? multiplayerPlayersManager)
+        public PlatformsGameInstaller(PlatformSpawner platformSpawner, [InjectOptional] MultiplayerPlayersManager? multiplayerPlayersManager)
         {
             _platformSpawner = platformSpawner;
             _multiplayerPlayersManager = multiplayerPlayersManager;
-            if (playerSpaceConvertor is not null)
-                _obstacleSaberSparkleEffectManager = playerSpaceConvertor.GetComponentInChildren<ObstacleSaberSparkleEffectManager>();
         }
 
         public override void InstallBindings()
         {
             Container.BindInterfacesAndSelfTo<BSEvents>().AsSingle();
-            if (_obstacleSaberSparkleEffectManager is not null)
-                Container.BindInstance(_obstacleSaberSparkleEffectManager).AsSingle().IfNotBound();
             if (_multiplayerPlayersManager is not null)
                 _multiplayerPlayersManager.playerSpawningDidFinishEvent += OnPlayerSpawningDidFinish;
         }

--- a/Plugin/CustomFloorPlugin/Plugin.cs
+++ b/Plugin/CustomFloorPlugin/Plugin.cs
@@ -35,6 +35,7 @@ namespace CustomFloorPlugin
         {
             zenjector.UseLogger(logger);
             zenjector.UseHttpService();
+            zenjector.Expose<ObstacleSaberSparkleEffectManager>("Gameplay");
             zenjector.Install<PlatformsAppInstaller>(Location.App, pluginMetadata.Assembly, config.Generated<PluginConfig>());
             zenjector.Install<PlatformsMenuInstaller>(Location.Menu);
             zenjector.Install<PlatformsGameInstaller>(Location.Player);


### PR DESCRIPTION
By manually binding the `ObstacleSaberSparkleEffectManager` other mods can no longer use the `Expose` method from SiraUtil.
This PR changes the manual binding to use `Expose` instead and let other mods expose the `ObstacleSaberSparkleEffectManager` as well.