### PR TITLE
Fix TubeLight mirroring and add more options + optimize mirrors

### DIFF
--- a/Plugin/CustomFloorPlugin/Behaviours/TrackMirror.cs
+++ b/Plugin/CustomFloorPlugin/Behaviours/TrackMirror.cs
@@ -44,7 +44,7 @@ namespace CustomFloorPlugin
             container.Inject(this);
             _mirror = gameObject.AddComponent<Mirror>();
             _rendererAccessor(ref _mirror) = GetComponent<MeshRenderer>();
-            _mirrorRendererAccessor(ref _mirror) = Instantiate(_mirrorRenderer);
+            _mirrorRendererAccessor(ref _mirror) = _mirrorRenderer;
             _mirrorMaterialAccessor(ref _mirror) = CreateMirrorMaterial();
             _noMirrorMaterialAccessor(ref _mirror) = CreateNoMirrorMaterial();
         }

--- a/Plugin/CustomFloorPlugin/Behaviours/TrackMirror.cs
+++ b/Plugin/CustomFloorPlugin/Behaviours/TrackMirror.cs
@@ -44,7 +44,7 @@ namespace CustomFloorPlugin
             container.Inject(this);
             _mirror = gameObject.AddComponent<Mirror>();
             _rendererAccessor(ref _mirror) = GetComponent<MeshRenderer>();
-            _mirrorRendererAccessor(ref _mirror) = _mirrorRenderer;
+            _mirrorRendererAccessor(ref _mirror) = Instantiate(_mirrorRenderer);
             _mirrorMaterialAccessor(ref _mirror) = CreateMirrorMaterial();
             _noMirrorMaterialAccessor(ref _mirror) = CreateNoMirrorMaterial();
         }

--- a/Plugin/CustomFloorPlugin/Behaviours/TubeLight.cs
+++ b/Plugin/CustomFloorPlugin/Behaviours/TubeLight.cs
@@ -41,7 +41,9 @@ namespace CustomFloorPlugin
         public float length = 1f;
         [Range(0, 1)] public float center = 0.5f;
         public Color color = Color.cyan;
+        public float colorAlphaMultiplier = 1f;
         public float bloomFogIntensityMultiplier = 1f;
+        public float boostToWhite = 0f;
         public LightsID lightsID;
 
         private MaterialSwapper? _materialSwapper;
@@ -53,6 +55,8 @@ namespace CustomFloorPlugin
 
         private static readonly FieldAccessor<ParametricBoxController, MeshRenderer>.Accessor _meshRendererAccessor = FieldAccessor<ParametricBoxController, MeshRenderer>.GetAccessor("_meshRenderer");
         private static readonly FieldAccessor<TubeBloomPrePassLight, float>.Accessor _centerAccessor = FieldAccessor<TubeBloomPrePassLight, float>.GetAccessor("_center");
+        private static readonly FieldAccessor<TubeBloomPrePassLight, float>.Accessor _colorAlphaMultiplierAccessor = FieldAccessor<TubeBloomPrePassLight, float>.GetAccessor("_colorAlphaMultiplier");
+        private static readonly FieldAccessor<TubeBloomPrePassLight, float>.Accessor _boostToWhiteAccessor = FieldAccessor<TubeBloomPrePassLight, float>.GetAccessor("_boostToWhite");
         private static readonly FieldAccessor<TubeBloomPrePassLight, ParametricBoxController>.Accessor _parametricBoxControllerAccessor = FieldAccessor<TubeBloomPrePassLight, ParametricBoxController>.GetAccessor("_parametricBoxController");
         private static readonly FieldAccessor<TubeBloomPrePassLight, BoolSO?>.Accessor _mainEffectPostProcessEnabledAccessor = FieldAccessor<TubeBloomPrePassLight, BoolSO?>.GetAccessor("_mainEffectPostProcessEnabled");
         private static readonly FieldAccessor<TubeBloomPrePassLightWithId, TubeBloomPrePassLight>.Accessor _tubeBloomPrePassLightAccessor = FieldAccessor<TubeBloomPrePassLightWithId, TubeBloomPrePassLight>.GetAccessor("_tubeBloomPrePassLight");
@@ -87,6 +91,7 @@ namespace CustomFloorPlugin
                     TubeBloomPrePassLight tubeBloomPrePassLight = gameObject.AddComponent<TubeBloomPrePassLight>();
                     GameObject boxLight = new("BoxLight");
                     boxLight.SetActive(false);
+                    boxLight.layer = 13; // NeonLight
                     Transform boxLightTransform = boxLight.transform;
                     boxLightTransform.transform.SetParent(transform);
                     boxLightTransform.transform.localRotation = Quaternion.Euler(Vector3.zero);
@@ -97,6 +102,8 @@ namespace CustomFloorPlugin
                     ParametricBoxController parametricBoxController = boxLight.AddComponent<ParametricBoxController>();
                     _meshRendererAccessor(ref parametricBoxController) = renderer;
                     _centerAccessor(ref tubeBloomPrePassLight) = center;
+                    _colorAlphaMultiplierAccessor(ref tubeBloomPrePassLight) = colorAlphaMultiplier;
+                    _boostToWhiteAccessor(ref tubeBloomPrePassLight) = boostToWhite;
                     _parametricBoxControllerAccessor(ref tubeBloomPrePassLight) = parametricBoxController;
                     _mainEffectPostProcessEnabledAccessor(ref tubeBloomPrePassLight) = _postProcessEnabled;
                     tubeBloomPrePassLight.width = width * 2;

--- a/Unity/Script/CustomFloorPlugin/TubeLight.cs
+++ b/Unity/Script/CustomFloorPlugin/TubeLight.cs
@@ -33,7 +33,9 @@ namespace CustomFloorPlugin
         [Range(0, 1)]
         public float center = 0.5f;
         public Color color = Color.cyan;
+        public float colorAlphaMultiplier = 1f;
         public float bloomFogIntensityMultiplier = 1f;
+        public float boostToWhite = 0f;
         public LightsID lightsID;
 
         private void OnDrawGizmos()


### PR DESCRIPTION
Allows you to change `colorAlphaMultiplier` and `boostToWhite` in TubeLights, also now properly sets BoxLight layer index to 13 (NeonLight) so they can be mirrored correctly.

Also, optimized mirrors by not instantiating the already existing MirrorRendererSO which should help reduce GPU load slightly.