### PR TITLE
Bump version for Baked Lighting

### DIFF
--- a/Plugin/CustomFloorPlugin/manifest.json
+++ b/Plugin/CustomFloorPlugin/manifest.json
@@ -3,7 +3,7 @@
   "id": "Custom Platforms",
   "name": "Custom Platforms",
   "author": "Rolo",
-  "version": "6.1.17",
+  "version": "6.1.18",
   "description": "A plugin to support custom platforms and environments",
   "gameVersion": "1.26.0",
   "dependsOn": {


### PR DESCRIPTION
Updated to version Custom Platforms 6.1.18.
Version wasn't previously bumped when the baked lighting fixes went in so there is a version with the fix and one without the fix marked as 6.1.17.